### PR TITLE
Fix for broken partition number parsing

### DIFF
--- a/src/iec_commands.cpp
+++ b/src/iec_commands.cpp
@@ -1159,6 +1159,8 @@ void IEC_Commands::FolderCommand()
 			char* in = (char*)channel.buffer;
 			int part;
 
+			in += 2;	// Skip command
+			
 			part = ParsePartition(&in);
 			if (part > 0)
 			{
@@ -1166,7 +1168,6 @@ void IEC_Commands::FolderCommand()
 				//Error(ERROR_74_DRlVE_NOT_READY);
 				return;
 			}
-			in += 2;	// Skip command
 			if (*in == ':')
 				in++;
 			MKDir(part, in);
@@ -1177,6 +1178,8 @@ void IEC_Commands::FolderCommand()
 			char* in = (char*)channel.buffer;
 			int part;
 
+			in += 2;	// Skip command
+			
 			part = ParsePartition(&in);
 			if (part > 0)
 			{
@@ -1184,7 +1187,6 @@ void IEC_Commands::FolderCommand()
 				//Error(ERROR_74_DRlVE_NOT_READY);
 				return;
 			}
-			in += 2;	// Skip command
 			if (*in == ':')
 				in++;
 			CD(part, in);


### PR DESCRIPTION
The FolderCommand() method attempts skip a partition number following the command but does so before skipping the command, so the effect is that the command is parsed as a number, then the command is skipped and the partition number is parsed as a path. This fix ensures that the command is skipped before the paritition number is skipped so the partition number isn't being parsed as a path later.
Fix by @bjonte